### PR TITLE
Using String Enum Constants instead of Strings and some code formatting

### DIFF
--- a/algo.py
+++ b/algo.py
@@ -32,6 +32,7 @@ symbol = 'BTC/USDT'
 data = exchange.fetch_ohlcv(symbol, timeframe='1m', limit=1000)
 closing_prices = np.array([candle[4] for candle in data])  # Closing prices
 
+
 # Market data processing
 def process_market_data(prices, data_queue, stop_flag):
     for price in prices:
@@ -40,6 +41,7 @@ def process_market_data(prices, data_queue, stop_flag):
         time.sleep(0.001)  # Simulate market data processing latency
         data_queue.put(price)
     stop_flag.set()
+
 
 # Order execution
 def execute_order(order_queue, stop_flag):
@@ -60,13 +62,16 @@ def execute_order(order_queue, stop_flag):
             logger.error(f"Error executing order: {e}")
             time.sleep(1)  # Wait before retrying
 
+
 def execute_buy_order(price):
     exchange.create_market_buy_order(symbol, 0.01)
     logger.info(f"Buy at {price}")
 
+
 def execute_sell_order(price):
     exchange.create_market_sell_order(symbol, 0.01)
     logger.info(f"Sell at {price}")
+
 
 # Trading strategy
 def ema_strategy(prices, short_ema_period, long_ema_period):
@@ -78,6 +83,7 @@ def ema_strategy(prices, short_ema_period, long_ema_period):
         return 'SELL'
     else:
         return 'HOLD'
+
 
 def bollinger_band_strategy(prices, window_size, num_std_dev):
     sma = np.mean(prices[-window_size:])
@@ -91,6 +97,7 @@ def bollinger_band_strategy(prices, window_size, num_std_dev):
         return 'BUY'
     else:
         return 'HOLD'
+
 
 # Main trading loop
 data_queue = queue.Queue()
@@ -114,13 +121,13 @@ position = 0
 while not stop_flag.is_set():
     try:
         current_price = data_queue.get(timeout=1)
-        
+
         # EMA strategy
         ema_signal = ema_strategy(closing_prices, short_ema_period, long_ema_period)
-        
+
         # Bollinger Bands strategy
         bb_signal = bollinger_band_strategy(closing_prices, bollinger_window_size, bollinger_num_std_dev)
-        
+
         # Buy or sell based on the signals
         if ema_signal == 'BUY' and bb_signal == 'BUY' and position < MAX_POSITION_SIZE:
             execute_buy_order(current_price)
@@ -128,7 +135,7 @@ while not stop_flag.is_set():
         elif ema_signal == 'SELL' and bb_signal == 'SELL' and position > -MAX_POSITION_SIZE:
             execute_sell_order(current_price)
             position -= 1
-        
+
         data_queue.task_done()
     except queue.Empty:
         break


### PR DESCRIPTION
there are two commits 
the first commit : 44f5224f07b28cb260818b419cf5a9c665a47c01
1) is just formatting the code to match PEP-8 guidelines like blank lines after function definition
2) having imports in the order of standard library -> 3rd party, in alphabetical order

whereas the second commit (0abe004cc7548dfaeda50a263d865875d8c82f60) is Using Str Enum constants instead of Strings

closes #4 